### PR TITLE
feat: Add (en cours) annotation for in-progress issues and simplify static filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Ce fichier définit le cadre technique, les conventions et les règles de concep
 *   **Concaténation :** Préférer les `f-strings` pour la concaténation de chaînes afin d'améliorer la lisibilité et les performances.
 *   **Recherche de membres (`in`) :** Utiliser des `sets` (ensembles) constants au niveau du module (ex: `IN_PROGRESS_STATUSES`) pour les vérifications d'appartenance à l'intérieur des boucles, garantissant un temps de recherche en O(1).
 *   **Logging :** Toujours envelopper les boucles ou traitements lourds utilisés uniquement pour le log de débogage dans une condition `if logger.isEnabledFor(logging.DEBUG):` pour éviter les coûts d'exécution (traversées O(N), allocations) lorsque le niveau de log est supérieur à DEBUG.
+*   **Commentaires :** Éviter les commentaires inutiles dans le code. Préférer utiliser un nommage explicite pour les variables et les fonctions. Si un commentaire est réellement nécessaire pour expliquer un choix technique complexe, il doit être rédigé **en anglais uniquement**.
 
 ## 3. Conventions de Test
 

--- a/config.ini.example
+++ b/config.ini.example
@@ -3,10 +3,6 @@ server = <host url>
 username = <username>
 api_token = <api token>
 project_key = <project key>
-# List of internal statuses to filter out when displaying static assigned tickets
-# (tickets assigned to the user that didn't move today).
-# Available internal statuses: TO_DO, IN_PROGRESS, TO_REVIEW, IN_REVIEW, TO_DEPLOY, TO_TEST, IN_TEST, DONE
-static_ticket_filtering = TO_DO, DONE
 
 [Report]
 username = <jira username used in issues>

--- a/src/config.py
+++ b/src/config.py
@@ -17,7 +17,6 @@ class JiraConfig:
     api_token: str
     project: str
     status_mapping: dict[str, Status]
-    static_ticket_filtering: set[Status]
 
 
 @dataclass
@@ -45,8 +44,6 @@ class Config:
 
     def _get_jira_config(self, config: configparser.ConfigParser) -> JiraConfig:
         status_mapping = self._get_status_mapping(config)
-        static_ticket_filtering_str = config.get('Jira', 'static_ticket_filtering', fallback='TO_DO, DONE')
-        static_ticket_filtering = {Status[s.strip().upper()] for s in static_ticket_filtering_str.split(',') if s.strip()}
 
         return JiraConfig(
             server=config.get('Jira', 'server'),
@@ -54,7 +51,6 @@ class Config:
             api_token=config.get('Jira', 'api_token'),
             project=config.get('Jira', 'project_key'),
             status_mapping=status_mapping,
-            static_ticket_filtering=static_ticket_filtering,
         )
 
     @staticmethod

--- a/src/issue.py
+++ b/src/issue.py
@@ -51,6 +51,8 @@ class Issue:
     status: Status
     assignee: str | None
     daily_actions: list[str]
+    status_category_key: str = ""
+    is_in_progress: bool = False
 
     def is_valid(self):
         return self.issue_key is not None and self.summary is not None and self.status is not None

--- a/src/jira_client.py
+++ b/src/jira_client.py
@@ -56,6 +56,8 @@ class JiraClient:
                 issue_type = jira_issue.fields.issuetype.name
                 current_status = map_status(jira_issue.fields.status, self.config.status_mapping)
                 assignee = jira_issue.fields.assignee.displayName if jira_issue.fields.assignee else None
+                status_category_key = jira_issue.fields.status.statusCategory.key
+                is_in_progress = (assignee == report_username and status_category_key != 'done')
 
                 issue_obj = Issue(
                     issue_key=jira_issue.key,
@@ -63,7 +65,9 @@ class JiraClient:
                     summary=jira_issue.fields.summary,
                     status=current_status,
                     assignee=assignee,
-                    daily_actions=[]
+                    daily_actions=[],
+                    status_category_key=status_category_key,
+                    is_in_progress=is_in_progress
                 )
                 issue_obj.extract_daily_actions(jira_issue, report_username, self.config.status_mapping)
                 issues_dict[issue_obj.issue_key] = issue_obj
@@ -71,8 +75,7 @@ class JiraClient:
             issues = list(issues_dict.values())
 
             for issue in issues:
-                if not issue.daily_actions and issue.status not in self.config.static_ticket_filtering and issue.assignee == report_username:
-                    # Tâche qui n'a pas bougé et qui n'est pas dans les statuts filtrés
+                if not issue.daily_actions and issue.status_category_key == 'indeterminate' and issue.assignee == report_username:
                     action = map_action_from_status(issue.issue_type, issue.status)
                     issue.daily_actions.append(str(action))
 

--- a/src/reporter.py
+++ b/src/reporter.py
@@ -28,6 +28,9 @@ class Reporter:
             if not issue.daily_actions:
                 continue
 
+            if issue.is_in_progress:
+                issue.daily_actions[-1] += " (en cours)"
+
             report_lines.append(f"* {issue.issue_key} {issue.summary}")
             for action in issue.daily_actions:
                 report_lines.append(f"  * {action}")

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -13,11 +13,11 @@ class TestReporter(unittest.TestCase):
 
     def test_generate_report(self):
         issues = [
-            Issue("PROJ-1", "Story", "First story", Status.IN_PROGRESS, "testuser", [Action.IMPLEMENTATION]),
-            Issue("PROJ-2", "Bug", "A bug to fix", Status.TO_DO, "anotheruser", [Action.FIX]),
-            Issue("PROJ-3", "Story", "A story in review", Status.IN_REVIEW, "testuser", [Action.REVIEW]),
-            Issue("PROJ-4", "Story", "A story in test", Status.IN_TEST, "testuser", [Action.TEST]),
-            Issue("PROJ-5", "Story", "A finished story", Status.DONE, "testuser", [Action.TEST]),
+            Issue("PROJ-1", "Story", "First story", Status.IN_PROGRESS, "testuser", [str(Action.IMPLEMENTATION)], is_in_progress=True),
+            Issue("PROJ-2", "Bug", "A bug to fix", Status.TO_DO, "anotheruser", [str(Action.FIX)], is_in_progress=False),
+            Issue("PROJ-3", "Story", "A story in review", Status.IN_REVIEW, "testuser", [str(Action.REVIEW)], is_in_progress=True),
+            Issue("PROJ-4", "Story", "A story in test", Status.IN_TEST, "testuser", [str(Action.TEST)], is_in_progress=True),
+            Issue("PROJ-5", "Story", "A finished story", Status.DONE, "testuser", [str(Action.TEST)], is_in_progress=False),
             Issue("PROJ-6", "Invalid Story", "This one is invalid", None, None, [])
         ]
 
@@ -29,13 +29,13 @@ class TestReporter(unittest.TestCase):
 
         self.assertEqual(output[0], "Daily Report")
         self.assertIn("* PROJ-1 First story", output)
-        self.assertIn(f"  * {Action.IMPLEMENTATION}", output)
+        self.assertIn(f"  * {Action.IMPLEMENTATION} (en cours)", output)
         self.assertIn("* PROJ-2 A bug to fix", output)
         self.assertIn(f"  * {Action.FIX}", output)
         self.assertIn("* PROJ-3 A story in review", output)
-        self.assertIn(f"  * {Action.REVIEW}", output)
+        self.assertIn(f"  * {Action.REVIEW} (en cours)", output)
         self.assertIn("* PROJ-4 A story in test", output)
-        self.assertIn(f"  * {Action.TEST}", output)
+        self.assertIn(f"  * {Action.TEST} (en cours)", output)
         self.assertIn("* PROJ-5 A finished story", output)
         self.assertIn(f"  * {Action.TEST}", output)
         # Check that the invalid issue is not in the report


### PR DESCRIPTION
Implement the "(en cours)" annotation for issues currently being worked on at the end of the day, streamline the filtering logic using Jira status categories instead of static configuration, and apply coding standard updates (English comments only).

---
*PR created automatically by Jules for task [8814279188308381937](https://jules.google.com/task/8814279188308381937) started by @Sorondare*